### PR TITLE
Add shadow info for 32270 (Technic Gear 12 Tooth Double Bevel)

### DIFF
--- a/parts/32270.dat
+++ b/parts/32270.dat
@@ -1,0 +1,9 @@
+0 LDCad shadow info for "Technic Gear 12 Tooth Double Bevel"
+
+0 Author: boergens
+0 !LICENSE CC BY-SA 4.0, see LICENSE.md
+
+0 !HISTORY 2026-02-15 {boergens} Initial info for 32270.dat
+
+0 !LDCAD SNAP_CLEAR
+0 !LDCAD SNAP_CYL [gender=F] [caps=none] [secs=A 6 20] [center=true] [slide=true] [ori=1 0 0 0 0 1 0 -1 0]


### PR DESCRIPTION
Adds snap connection info for part **32270** — Technic Gear 12 Tooth Double Bevel.

## Definition

```
0 !LDCAD SNAP_CYL [gender=F] [caps=none] [secs=A 6 20] [center=true] [slide=true] [ori=1 0 0 0 0 1 0 -1 0]
```

Central axle hole — identical to **32269** (Technic Gear 20 Tooth Double Bevel). Both gears share the same standard Technic axle hole geometry: F gender, axle cross-section, centered slide along the Neg Z axis.

## Validation

- Confirmed the definition matches the existing 32269.dat pattern
- Cross-referenced with other sliding axle hole gears in the library (11955, 6573) which all use `secs=A 6 20` for the standard axle receptacle
- Tested with LEGO 10190 (Market Street) MPD — gear correctly connects to its axle placement