### PR TITLE
Add tyre/rim snap pairing for 3641 and 4624

### DIFF
--- a/parts/3641.dat
+++ b/parts/3641.dat
@@ -1,0 +1,8 @@
+0 LDCad shadow info for "Tyre  6/ 50 x  8 Offset Tread"
+
+0 Author: LDCad Shadow Library
+0 !LICENSE CC BY-SA 4.0, see LICENSE.md
+
+0 !HISTORY 2026-02-19 {Kevin} Initial info for 3641.dat
+
+0 !LDCAD SNAP_GEN [group=rim8_6] [gender=F] [bounding=cyl 8 3] [ori=1 0 0 0 0 -1 0 1 0]

--- a/parts/4624.dat
+++ b/parts/4624.dat
@@ -4,5 +4,7 @@
 0 !LICENSE CC BY-SA 4.0, see LICENSE.md
 
 0 !HISTORY 2015-12-17 {Philippe Hurbain} Initial info for 4624.dat
+0 !HISTORY 2026-02-19 {Kevin} Add tyre mount for 3641
 
 0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 4 10   R 5 2] [pos=0 0 8] [ori=1 0 0 0 0 -1 0 1 0]
+0 !LDCAD SNAP_GEN [group=rim8_6] [gender=M] [bounding=cyl 10 3.5] [ori=1 0 0 0 0 -1 0 1 0]


### PR DESCRIPTION
## Summary
- New shadow file for **3641.dat** (Tyre 6/50 x 8 Offset Tread): F GEN `group=rim8_6`
- Updated **4624.dat** (Wheel Rim 6.4 x 8): added M GEN `group=rim8_6` tyre mount, existing axle hole snap preserved

Uses the same GEN group-based approach as the existing 32003/32004b and 32019/32020 tyre-rim pairs.